### PR TITLE
penguins: resolve NoneType error for get_most_fish

### DIFF
--- a/socha/api/plugin/penguins.py
+++ b/socha/api/plugin/penguins.py
@@ -671,7 +671,8 @@ class Board:
 
         :return: A list of Fields.
         """
-        fields = self.get_all_fields()
+
+        fields = list(filter(lambda field_x: not field_x.is_occupied(), self.get_all_fields()))
         fields.sort(key=lambda field_x: field_x.get_fish(), reverse=True)
         for i, field in enumerate(fields):
             if field.get_fish() < fields[0].get_fish():


### PR DESCRIPTION
Resolves a bug that causes "TypeError: '<' not supported between instances of 'NoneType' and 'int'"

The field list is sorted using get_fish(). get_fish returns None if the field is occupied.
Because of this occupied fields have to be filtered before trying to sort the list.